### PR TITLE
Change OS detection.

### DIFF
--- a/src/run-tests
+++ b/src/run-tests
@@ -24,7 +24,7 @@ $_SERVER['argv'][++$position] = '-p';
 $_SERVER['argv'][++$position] = 'php';
 $_SERVER['argv'][++$position] = '-c';
 
-$os = stristr(PHP_OS, 'LINUX') ? 'unix' : 'win';
+$os = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? 'win' : 'unix';
 $_SERVER['argv'][++$position] = $testsDir . "/php-$os.ini";
 
 // $_SERVER['argv'][++$position] = '--coverage';


### PR DESCRIPTION
Unix platforms can return more variants than just Linux.

For example, OS X returns Darwin and Testbench is therefore looking for php-win.ini

See https://en.wikipedia.org/wiki/Uname#Table_of_standard_uname_output
