### PR TITLE
Using with prepared testing database

### DIFF
--- a/src/Mocks/DoctrineConnectionMock.php
+++ b/src/Mocks/DoctrineConnectionMock.php
@@ -54,10 +54,8 @@ class DoctrineConnectionMock extends \Kdyby\Doctrine\Connection implements \Test
 
 		$config = $container->parameters['testbench'];
 
-		if (isset($config['sqls'])) {
-			foreach ($container->parameters['testbench']['sqls'] as $file) {
-				\Kdyby\Doctrine\Dbal\BatchImport\Helpers::loadFromFile($connection, $file);
-			}
+		foreach ($container->parameters['testbench']['sqls'] as $file) {
+			\Kdyby\Doctrine\Dbal\BatchImport\Helpers::loadFromFile($connection, $file);
 		}
 
 		if (isset($config['migrations']) && $config['migrations'] === TRUE) {
@@ -113,9 +111,9 @@ class DoctrineConnectionMock extends \Kdyby\Doctrine\Connection implements \Test
 	{
 		//connect to an existing database other than $this->_databaseName
 		if ($databaseName === NULL) {
-			$config = $container->parameters['testbench'];
-			if (isset($config['dbname'])) {
-				$databaseName = $config['dbname'];
+			$dbName = $container->parameters['testbench']['dbname'];
+			if ($dbName) {
+				$databaseName = $dbName;
 			} elseif ($connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
 				$databaseName = 'postgres';
 			} else {

--- a/src/Mocks/DoctrineConnectionMock.php
+++ b/src/Mocks/DoctrineConnectionMock.php
@@ -37,6 +37,11 @@ class DoctrineConnectionMock extends \Kdyby\Doctrine\Connection implements \Test
 			}
 			try {
 				$this->__testbench_database_setup($connection, $container);
+			} catch(\Doctrine\DBAL\Migrations\MigrationException $e) {
+				//don't throw exception if no migration is present
+				if ($e->getCode() != 4) {
+					\Tester\Assert::fail($e->getMessage());
+				}
 			} catch (\Exception $e) {
 				\Tester\Assert::fail($e->getMessage());
 			}

--- a/src/Mocks/NetteDatabaseConnectionMock.php
+++ b/src/Mocks/NetteDatabaseConnectionMock.php
@@ -16,16 +16,20 @@ class NetteDatabaseConnectionMock extends \Nette\Database\Connection implements 
 	public function __construct($dsn, $user = NULL, $password = NULL, array $options = NULL)
 	{
 		$container = \Testbench\ContainerFactory::create(FALSE);
-		$this->onConnect[] = function (NetteDatabaseConnectionMock $connection) use ($container) {
-			if ($this->__testbench_databaseName !== NULL) { //already initialized (needed for pgsql)
-				return;
-			}
-			try {
-				$this->__testbench_database_setup($connection, $container);
-			} catch (\Exception $e) {
-				\Tester\Assert::fail($e->getMessage());
-			}
-		};
+
+		if ($container->parameters['testbench']['setupDatabase']) {
+			$this->onConnect[] = function (NetteDatabaseConnectionMock $connection) use ($container) {
+				if ($this->__testbench_databaseName !== NULL) { //already initialized (needed for pgsql)
+					return;
+				}
+				try {
+					$this->__testbench_database_setup($connection, $container);
+				} catch (\Exception $e) {
+					\Tester\Assert::fail($e->getMessage());
+				}
+			};
+		}
+
 		parent::__construct($dsn, $user, $password, $options);
 	}
 

--- a/src/Mocks/NetteDatabaseConnectionMock.php
+++ b/src/Mocks/NetteDatabaseConnectionMock.php
@@ -41,11 +41,9 @@ class NetteDatabaseConnectionMock extends \Nette\Database\Connection implements 
 		$this->__testbench_database_drop($connection, $container);
 		$this->__testbench_database_create($connection, $container);
 
-		if (isset($container->parameters['testbench']['sqls'])) {
-			foreach ($container->parameters['testbench']['sqls'] as $file) {
-				\Nette\Database\Helpers::loadFromFile($connection, $file);
-			}
-		}
+        foreach ($container->parameters['testbench']['sqls'] as $file) {
+            \Nette\Database\Helpers::loadFromFile($connection, $file);
+        }
 
 		register_shutdown_function(function () use ($connection, $container) {
 			$this->__testbench_database_drop($connection, $container);
@@ -89,9 +87,9 @@ class NetteDatabaseConnectionMock extends \Nette\Database\Connection implements 
 	{
 		//connect to an existing database other than $this->_databaseName
 		if ($databaseName === NULL) {
-			$config = $container->parameters['testbench'];
-			if (isset($config['dbname'])) {
-				$databaseName = $config['dbname'];
+			$dbName = $container->parameters['testbench']['dbname'];
+			if ($dbName) {
+				$databaseName = $dbName;
 			} elseif ($connection->getSupplementalDriver() instanceof PgSqlDriver) {
 				$databaseName = 'postgres';
 			} else {

--- a/src/TestbenchExtension.php
+++ b/src/TestbenchExtension.php
@@ -80,7 +80,7 @@ class TestbenchExtension extends \Nette\DI\CompilerExtension
 							$sectionConfig['dsn'],
 							isset($sectionConfig['user']) ? $sectionConfig['user'] : null,
 							isset($sectionConfig['password']) ? $sectionConfig['password'] : null,
-							isset($extensionConfig['options']) ? ($extensionConfig['options'] + ['lazy' => TRUE]) : [],
+							isset($sectionConfig['options']) ? ($sectionConfig['options'] + ['lazy' => TRUE]) : [],
 						]);
 				}
 			}

--- a/src/TestbenchExtension.php
+++ b/src/TestbenchExtension.php
@@ -75,8 +75,8 @@ class TestbenchExtension extends \Nette\DI\CompilerExtension
 					$builder->getDefinition($definitionName)
 						->setClass('Testbench\Mocks\NetteDatabaseConnectionMock', [
 							$sectionConfig['dsn'],
-							$sectionConfig['user'],
-							$sectionConfig['password'],
+							isset($sectionConfig['user']) ? $sectionConfig['user'] : null,
+							isset($sectionConfig['password']) ? $sectionConfig['password'] : null,
 							isset($extensionConfig['options']) ? ($extensionConfig['options'] + ['lazy' => TRUE]) : [],
 						]);
 				}

--- a/src/TestbenchExtension.php
+++ b/src/TestbenchExtension.php
@@ -12,6 +12,10 @@ class TestbenchExtension extends \Nette\DI\CompilerExtension
 		if (!isset($testbenchConfig['url'])) {
 			$testbenchConfig['url'] = 'http://test.bench/';
 		}
+
+		if (!isset($testbenchConfig['setupDatabase'])) {
+			$testbenchConfig['setupDatabase'] = true;
+		}
 		$builder->parameters[$this->name] = $testbenchConfig;
 
 		$this->prepareDoctrine();

--- a/src/TestbenchExtension.php
+++ b/src/TestbenchExtension.php
@@ -4,19 +4,18 @@ namespace Testbench;
 
 class TestbenchExtension extends \Nette\DI\CompilerExtension
 {
+	private $defaultConfig = [
+		'url' => 'http://test.bench/',
+		'setupDatabase' => true,
+		'sqls' => [],
+		'dbname' => null,
+	];
 
 	public function loadConfiguration()
 	{
 		$builder = $this->compiler->getContainerBuilder();
-		$testbenchConfig = $this->getConfig();
-		if (!isset($testbenchConfig['url'])) {
-			$testbenchConfig['url'] = 'http://test.bench/';
-		}
 
-		if (!isset($testbenchConfig['setupDatabase'])) {
-			$testbenchConfig['setupDatabase'] = true;
-		}
-		$builder->parameters[$this->name] = $testbenchConfig;
+		$builder->parameters[$this->name] = $this->getConfig($this->defaultConfig);
 
 		$this->prepareDoctrine();
 		$this->prepareNetteDatabase($builder);
@@ -69,8 +68,8 @@ class TestbenchExtension extends \Nette\DI\CompilerExtension
 				$builder->getDefinition($definitionName)
 					->setClass('Testbench\Mocks\NetteDatabaseConnectionMock', [
 						$extensionConfig['dsn'],
-						$extensionConfig['user'],
-						$extensionConfig['password'],
+						isset($extensionConfig['user']) ? $extensionConfig['user'] : null,
+						isset($extensionConfig['password']) ? $extensionConfig['password'] : null,
 						isset($extensionConfig['options']) ? ($extensionConfig['options'] + ['lazy' => TRUE]) : [],
 					]);
 			} else {

--- a/src/Traits/TPresenter.php
+++ b/src/Traits/TPresenter.php
@@ -150,6 +150,31 @@ trait TPresenter
 	}
 
 	/**
+	 * @param string $destination
+	 * @param string $signal
+	 * @param array $params
+	 * @param array $post
+	 *
+	 * @return \Nette\Application\IResponse
+	 */
+	protected function checkAjaxSignal($destination, $signal, $params = [], $post = [])
+	{
+		$this->__testbench_ajaxMode = TRUE;
+
+		$params += ['do' => $signal];
+
+		$response = $this->check($destination, $params, $post);
+
+		Assert::true($this->__testbench_presenter->isAjax());
+		if (!$this->__testbench_exception) {
+			Assert::same(200, $this->getReturnCode());
+			Assert::type('Nette\Application\Responses\JsonResponse', $response);
+		}
+		$this->__testbench_ajaxMode = FALSE;
+		return $response;
+	}
+
+	/**
 	 * @param string $destination fully qualified presenter name (module:module:presenter)
 	 * @param string $path
 	 * @param array $params provided to the presenter usually via URL

--- a/tests/php.ini
+++ b/tests/php.ini
@@ -1,0 +1,10 @@
+[PHP]
+extension=json.so
+extension=tokenizer.so
+extension=dom.so
+extension=simplexml.so
+extension=mysqlnd.so
+extension=pdo.so
+extension=pdo_mysql.so
+
+


### PR DESCRIPTION
- not everyone want setup database automatically (create db, drop db, apply migrations etc.)
- better handling default configuration parameters
- add php.ini for testing with required extensions
- add checkAjaxSignal method for testing signal called from AJAX
