### PR TITLE
PHP 7.2 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 services:
   - mysql
@@ -14,6 +15,10 @@ env:
   - DB=mysql RUNLEVEL=10
   - DB=pgsql RUNLEVEL=0
   - DB=pgsql RUNLEVEL=10
+
+matrix:
+    allow_failures:
+        - php: 7.2
 
 before_script:
   - composer selfupdate --no-progress

--- a/src/ContainerFactory.php
+++ b/src/ContainerFactory.php
@@ -5,8 +5,9 @@ namespace Testbench;
 /**
  * @internal
  */
-class ContainerFactory extends \Nette\Object
+class ContainerFactory
 {
+	use \Nette\SmartObject;
 
 	private static $container;
 


### PR DESCRIPTION
PHP 7.2 does not allow to use Object as class name, any attempt to extend it (Nette\Object here) results in a fatal error. So I used trait Nette\SmartObject instead.
Tests on PHP 7.2 still fail because of Kdyby packages which still use Nette\Object. If one does not use Doctrine, there should be no errors (I believe).